### PR TITLE
GitHub Actions for publishing Docker Containers to GitHub CR (DEVWF-T007)

### DIFF
--- a/.github/workflows/fabrikam-init.yml
+++ b/.github/workflows/fabrikam-init.yml
@@ -1,4 +1,4 @@
-name: Fabrikam API Build
+name: Fabrikam Init Build
 
 on:
   push:
@@ -6,8 +6,8 @@ on:
     branches:
       - main
     paths:
-      - 'content-api/**'
-      - '.github/workflows/fabrikam-api.yml'      
+      - 'content-init/**'
+      - '.github/workflows/fabrikam-init.yml'
 
     # Publish `v1.2.3` tags as releases.
     tags:
@@ -18,7 +18,7 @@ on:
 
 env:
   # TODO: Change variable to your image's name.
-  IMAGE_NAME: fabrikam-api
+  IMAGE_NAME: fabrikam-init
 
 jobs:
   # Push image to GitHub Packages.
@@ -31,14 +31,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        working-directory: content-api
+        working-directory: content-init
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into GitHub Container Registry
         run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image to GitHub Container Registry
-        working-directory: content-api
+        working-directory: content-init
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
 

--- a/.github/workflows/fabrikam-web.yml
+++ b/.github/workflows/fabrikam-web.yml
@@ -1,4 +1,4 @@
-name: Fabrikam API Build
+name: Fabrikam Web Build
 
 on:
   push:
@@ -6,8 +6,9 @@ on:
     branches:
       - main
     paths:
-      - 'content-api/**'
-      - '.github/workflows/fabrikam-api.yml'      
+      - 'content-web/**'
+      - '.github/workflows/fabrikam-web.yml'
+      
 
     # Publish `v1.2.3` tags as releases.
     tags:
@@ -18,7 +19,7 @@ on:
 
 env:
   # TODO: Change variable to your image's name.
-  IMAGE_NAME: fabrikam-api
+  IMAGE_NAME: fabrikam-web
 
 jobs:
   # Push image to GitHub Packages.
@@ -31,14 +32,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        working-directory: content-api
+        working-directory: content-web
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into GitHub Container Registry
         run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image to GitHub Container Registry
-        working-directory: content-api
+        working-directory: content-web
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
 


### PR DESCRIPTION

# Instructions to Fix the exercise

Added these 3 GitHub Actions. They trigger automatically when a new commit happens in the files associated to the build.

> One thing to Do.
>
> Create a new GitHub Secret called `CR_PAT` that contains your Personal Access Token with write:packages and read:packages permissions

Linked to [AB#3021](https://dev.azure.com/osnabrugge/d1f00651-c742-4722-91a8-96b41e8f2bc4/_workitems/edit/3021)