### PR TITLE
Added Docker Compose files to deploy applications to Azure Web App (MOVECLOUD-T002 Solution)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
 version: "3.4"
 services:
   api:
-    image: ghcr.io/renevanosnabrugge/fabrikam-api:latest
+    image: ghcr.io/<yourgithubaccount>/fabrikam-api:latest
     ports:
       - "3001:3001"
 
   web:
-      image: ghcr.io/renevanosnabrugge/fabrikam-web:latest
-      depends_on:
-          - api
-      environment:
-          CONTENT_API_URL: http://api:3001
-      ports:
-          - "3000:80"       
+    image: ghcr.io/<yourgithubaccount>/fabrikam-web:latest
+    depends_on:
+        - api
+    environment:
+        CONTENT_API_URL: http://api:3001
+    ports:
+        - "3000:80"       


### PR DESCRIPTION


# Instructions to Fix the exercise
Added a new docker-compose file (docker-compose) to configure the multi-container web application. To deploy this file, update the name of the container registry and change the CosmosDB connectionstring

```powershell
$studentprefix = "your abbreviation here"
$resourcegroupName = "fabmedical-rg-" + $studentprefix
$webappName = "fabmedical-web-" + $studentprefix

$ghpat=Read-Host -Prompt "Github Personal Access Token"

az webapp config container set `
--docker-registry-server-password $ghpat `
--docker-registry-server-url https://ghcr.io `
--docker-registry-server-user notapplicable `
--multicontainer-config-file docker-compose-prod.yml `
--multicontainer-config-type COMPOSE `
--name $webappName `
--resource-group $resourcegroupName 
```

Linked to [AB#3022](https://dev.azure.com/osnabrugge/d1f00651-c742-4722-91a8-96b41e8f2bc4/_workitems/edit/3022)