### PR TITLE
Updated deployment file and GitHub Actions file (CLOSELOOP-T002)

### DIFF
--- a/.github/workflow/docker-publish.yml
+++ b/.github/workflow/docker-publish.yml
@@ -1,0 +1,37 @@
+name: Docker Compose Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and Push image
+        run: |
+          docker-compose -f docker-compose.yml -f build.docker-compose.yml build
+          docker-compose -f docker-compose.yml -f build.docker-compose.yml push
+          
+      - name: Login on Azure CLI
+        uses: azure/login@v1.1
+        with:
+          creds: ${{secrets.AZURE_CREDENTIALS}}
+
+      - name: Deploy Infrastructure
+        shell: pwsh
+        run: |
+          .\infrastructure\deploy-infrastructure.ps1 -studentprefix <your abbreviation>
+          
+ 
+          

--- a/build.docker-compose.yml
+++ b/build.docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.4"
+services:
+  api:
+    build: ./content-api
+
+  web:
+    build: ./content-web

--- a/infrastructure/deploy-infrastructure.ps1
+++ b/infrastructure/deploy-infrastructure.ps1
@@ -1,25 +1,51 @@
-$studentprefix = "your abbreviation here"
+param
+(
+    [string] $studentprefix = "tst"
+)
+
 $resourcegroupName = "fabmedical-rg-" + $studentprefix
 $cosmosDBName = "fabmedical-cdb-" + $studentprefix
 $webappName = "fabmedical-web-" + $studentprefix
 $planName = "fabmedical-plan-" + $studentprefix
 $location1 = "westeurope"
 $location2 = "northeurope"
+$appInsights = "fabmedicalai-" + $studentsuffix
 
 #First create a group
-$resultRG = az group create --name $resourcegroupName --location $location1 | ConvertFrom-Json
+$rg = az group create --name $resourcegroupName --location $location1 | ConvertFrom-Json 
 
 #Then create a CosmosDB
-$resultCosmos = az cosmosdb create --name $cosmosDBName `
+az cosmosdb create --name $cosmosDBName `
 --resource-group $resourcegroupName `
 --locations regionName=$location1 failoverPriority=0 isZoneRedundant=False `
 --locations regionName=$location2 failoverPriority=1 isZoneRedundant=True `
 --enable-multiple-write-locations `
---kind MongoDB `
-| ConvertFrom-Json
+--kind MongoDB
 
 #Create a Azure App Service Plan
 az appservice plan create --name $planName --resource-group $resourcegroupName --sku S1 --is-linux
 
+az webapp config appsettings set --settings DOCKER_REGISTRY_SERVER_USERNAME="https://ghcr.io" --name $($webappName) --resource-group $($resourcegroupName) 
+az webapp config appsettings set --settings DOCKER_REGISTRY_SERVER_URL="notapplicable" --name $($webappName) --resource-group $($resourcegroupName) 
+az webapp config appsettings set --settings DOCKER_REGISTRY_SERVER_PASSWORD="$($env:CR_PAT)" --name $($webappName) --resource-group $($resourcegroupName) 
+
+
 #Create a Azure Web App with NGINX container
-az webapp create --resource-group $resourcegroupName --plan $planName --name $webappName -i nginx
+az webapp create `
+--multicontainer-config-file docker-compose.yml `
+--multicontainer-config-type COMPOSE `
+--name $($webappName) `
+--resource-group $($resourcegroupName) `
+--plan $($planName)
+
+az webapp config container set `
+--docker-registry-server-password $($env:CR_PAT) `
+--docker-registry-server-url https://ghcr.io `
+--docker-registry-server-user notapplicable `
+--multicontainer-config-file docker-compose.yml `
+--multicontainer-config-type COMPOSE `
+--name $($webappName) `
+--resource-group $resourcegroupName 
+
+az monitor app-insights component create --app $appInsights --location $location1 --kind web -g $resourcegroupName --application-type web --retention-time 120
+


### PR DESCRIPTION

# Instructions to Fix the exercise

Modified the deployment script to have the prefix as a parameter and added the GitHub Secret environment variable instead of a local variable. To run the deployment locally, add a environment variable first that contains the GitHub Personal Access Token to pull images from the GitHub Container Registry.

```PowerShell
# Personal Access Token should be pre-configured by setup.
# $env:CR_PAT="Your Pat Here" 
./infrastructure/deploy-infrastructure.ps1
```

Also modified the GitHub Action so that it deploys the latest version of the containers to the Azure WebApp. To run the pipeline added a GitHub Secret called `AZURE_CREDENTIALS`, that contains the secrets to deploy to the resource group. Run this snippet and paste completely in the secret value.

```PowerShell
$studentprefix ="your abbreviation here"
$resourcegroupName = "fabmedical-rg-" + $studentprefix 
$rg = az group show --name $resourcegroupName | ConvertFrom-Json
az ad sp create-for-rbac --name "codetocloud-$studentprefix" --sdk-auth --role contributor --scopes $($rg.id)
```

Copy the output as value of the GitHub Secret AZURE_CREDENTIALS